### PR TITLE
ci: add PR build validation, PR template and labeling workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+
+### Description of changes
+* Describe *what* you're changing and *why* you're doing these changes.
+
+### Tests
+* Describe how you validated the changes (e.g. `make prod` builds successfully, pages render as expected).
+* Attach screenshots when the change affects the rendered website.
+
+### References
+* Link to related open issues.
+* Link to related PRs.
+* Link to documentation useful to understand the changes.
+
+### Checklist
+- Make sure you are pointing to **the right branch**.
+- Check all commits' messages are clear, describing what and why vs how.
+- Make sure the website **builds successfully** (`make prod`).
+- Check if documentation is impacted by this change.
+
+By submitting this pull request, I confirm that my contribution is compliant with
+the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/master/LICENSE).

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,34 @@
+Content:
+  - changed-files:
+      - any-glob-to-any-file:
+        - content/**
+        - archetypes/**
+Styling:
+  - changed-files:
+      - any-glob-to-any-file:
+        - src/**
+        - assets/**
+Build:
+  - changed-files:
+      - any-glob-to-any-file:
+        - gulpfile.js
+        - config.yaml
+        - Makefile
+        - scripts/**
+Dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+        - package.json
+        - package-lock.json
+Documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+        - README.md
+        - LICENSE
+Developer Experience:
+  - changed-files:
+      - any-glob-to-any-file:
+        - .github/**
+        - .gitignore
+        - .nvmrc
+        - .pre-commit-config.yaml

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,65 @@
+labels:
+  - name: Build
+    description: Changes to the build system or tooling.
+    color: 1D76DB
+  - name: Bug
+    description: Something isn't working.
+    color: D73A4A
+  - name: Content
+    description: Improvements or additions to website content.
+    color: 0E8A16
+  - name: Dependencies
+    description: Changes to dependencies.
+    color: 4DD3AD
+  - name: Developer Experience
+    description: Improvements or additions related to developer experience.
+    color: A4418D
+  - name: Documentation
+    description: Improvements or additions to documentation.
+    color: F7AC22
+  - name: Duplicate
+    description: This issue or pull request already exists.
+    color: CFD3D7
+  - name: Enhancement
+    description: New feature or improvement.
+    color: A2EEEF
+  - name: Help Wanted
+    description: Extra attention is needed.
+    color: 008672
+  - name: Invalid
+    description: This doesn't seem right.
+    color: E4E669
+  - name: Question
+    description: Further information is requested.
+    color: D876E3
+  - name: Security
+    description: Improvements or additions related to security.
+    color: 15631C
+  - name: Styling
+    description: Changes to styles, scripts or static assets.
+    color: 95C8EA
+  - name: Triage
+    description: The issue must be triaged.
+    color: 985721
+  - name: Wont Fix
+    description: This will not be worked on.
+    color: FFFFFF
+
+repos:
+  - name: gmarciani/gmarciani.github.io
+    labels:
+      - Build
+      - Bug
+      - Content
+      - Dependencies
+      - Developer Experience
+      - Documentation
+      - Duplicate
+      - Enhancement
+      - Help Wanted
+      - Invalid
+      - Question
+      - Security
+      - Styling
+      - Triage
+      - Wont Fix

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,0 +1,58 @@
+name: CI/CD
+
+on:
+  pull_request:
+    branches:
+      - master
+
+# Cancel in-progress runs for the same PR when new commits are pushed.
+concurrency:
+  group: cicd-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Validate the PR by building the website, exactly as it is built for
+  # production. A failing build blocks the PR from being merged.
+  build:
+    name: Build Website
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.153.3
+    steps:
+
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install ImageMagick
+        run: sudo apt-get install -y imagemagick
+
+      - name: Install Dart-Sass
+        run: sudo snap install dart-sass
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Build Assets
+        run: make build
+
+      - name: Build with Hugo
+        env:
+          # For maximum backward compatibility with Hugo modules
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: make prod

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,16 @@
+# This workflow assigns labels to PRs according to the rules defined in .github/labeler.yaml.
+name: PR Labeler
+
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yaml

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,0 +1,27 @@
+name: Sync Labels
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/labels.yaml
+      - .github/workflows/sync-labels.yaml
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Sync Labels
+        uses: b4b4r07/github-labeler@master
+        with:
+          config: .github/labels.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add cicd.yaml workflow that validates PRs by building the website
  (Hugo + Gulp assets), intended as a required status check for merge.
- Add pull request template.
- Add PR labeler workflow and configuration.
- Add label definitions and a sync-labels workflow to provision them.