### PR TITLE
docs: add CI/CD workflow status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![GMARCIANI Logo](src/images/logo/gm-logo.svg)
 
+[![CI/CD](https://github.com/gmarciani/gmarciani.github.io/actions/workflows/cicd.yaml/badge.svg)](https://github.com/gmarciani/gmarciani.github.io/actions/workflows/cicd.yaml)
+
 Personal blog at [gmarciani.github.io](https://gmarciani.github.io).
 
 ## Requirements


### PR DESCRIPTION
### Description of changes
* Adds a CI/CD workflow status badge to the README so the build health of `master` is visible at a glance.
* Also serves to exercise and verify the newly added PR checks (`Build Website` build validation and `PR Labeler`).

### Tests
* The `Build Website` check on this PR validates that the website still builds (`make build` + `make prod`).

### References
* Follow-up to the CI/CD, PR template and labeling workflows added previously.

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U81LNjQUq7unoc7Ndnt9hV)_