### PR TITLE
build(deps): bump npm-check-updates from 19.6.6 to 22.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {
     "gulp-cli": "^3.1.0",
-    "npm-check-updates": "^19.6.3"
+    "npm-check-updates": "^22.2.1"
   }
 }


### PR DESCRIPTION
### Description of changes
* Consolidates the three open Dependabot dependency updates for `npm-check-updates` into a single PR.
* All three bump the same dependency to progressively higher versions, so they supersede one another; this PR moves it to the latest, `^22.2.1`, which covers all of them:
  * #16 — bump to `20.0.0`
  * #17 — bump to `22.0.1`
  * #18 — bump to `22.2.1`

### Tests
* The `Build Website` CI check validates that the website still builds (`make build` + `make prod`) with the updated dependency.

### References
* Supersedes Dependabot PRs #16, #17 and #18 (to be closed once this is merged).

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U81LNjQUq7unoc7Ndnt9hV)_