### PR TITLE
fix(hugo): exclude content/CLAUDE.md from the build (fixes broken deploy)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,11 @@
 title: GM
 baseURL: https://gmarciani.github.io/
 languageCode: en-us
+# Exclude non-content Markdown from the build. content/CLAUDE.md is authoring
+# guidance for agents, not a page: without this Hugo executes its example
+# shortcodes (breaking `hugo --gc`) and would publish it at /claude/.
+ignoreFiles:
+  - content/CLAUDE\.md$
 pagination:
   pagerSize: 20
 markup:


### PR DESCRIPTION
### Description of changes
* The production deploy is currently **broken**: deploy run #47 (merge of #23) failed, and every new PR's `Build Website` check fails too.
* Root cause: `content/CLAUDE.md` (agent authoring guidance, added in #23) lives under `content/`, so Hugo treats it as a page. It contains an example of the `ref` shortcode pointing at a non-existent page; Hugo executes shortcodes in raw content, so `hugo --gc` aborts with `REF_NOT_FOUND`. It would also have been published as a page at `/claude/`.
* Fix: add `ignoreFiles: ['content/CLAUDE\.md$']` to `config.yaml` so Hugo skips the file entirely — no build error, not published — while it stays in `content/` for authors.

### Tests
* The `Build Website` CI check validates `make build` + `make prod` now succeed.

### References
* Regression from #23 (`claude/blog-social-seo-ai`).
* Unblocks #24 (dependency range loosening), which will be rebased on top once this merges.

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U81LNjQUq7unoc7Ndnt9hV)_