### PR TITLE
docs: single Claude attribution in PR template; require template in CLAUDE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,3 +19,6 @@
 
 By submitting this pull request, I confirm that my contribution is compliant with
 the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/master/LICENSE).
+
+---
+_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,7 @@ Detailed content-authoring guidance — post structure, quoting posts, and the b
 ## Deployment
 
 GitHub Actions (`.github/workflows/deploy.yaml`) deploys to GitHub Pages on push to `master`: installs Hugo extended + Node + ImageMagick + Dart Sass, runs `make build` then `make prod`, and publishes `public/`. Base URL comes from the `BASE_URL` env var (defaults to `https://gmarciani.github.io/`).
+
+## Pull requests
+
+Every PR **must follow `.github/PULL_REQUEST_TEMPLATE.md`** — mirror its sections (Description of changes, Tests, References, Checklist) and fill each from the actual changes. The template already ends with the "created with the assistance of Claude Code" attribution, so **do not add a second attribution** (no extra "Generated with Claude Code" footer) — keep exactly one, the template's.


### PR DESCRIPTION
### Description of changes
* Adds a single "created with the assistance of Claude Code" attribution line to `.github/PULL_REQUEST_TEMPLATE.md`, so the attribution lives in exactly one place instead of being duplicated by an extra footer in each PR body.
* Documents in `CLAUDE.md` that every PR **must follow the template** (mirror its sections) and **must not add a second attribution** — keep only the template's.

*Why:* PR bodies were carrying two "created with Claude" mentions (the intended template attribution plus an appended "Generated with Claude Code" footer). This makes the single attribution canonical and codifies the rule so future PRs don't reintroduce the duplication.

### Tests
* Documentation/repo-metadata change only — no source, template (Pug/Hugo), config, or content touched, so `make build` / `make prod` are unaffected.
* This PR's own description follows the updated template and carries a single attribution.

### References
* Relates to the PR-template and labeling workflows added earlier.

### Checklist
- [x] Make sure you are pointing to **the right branch**. (base: `master`)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure the website **builds successfully** (`make prod`). — unaffected; docs only.
- [x] Check if documentation is impacted by this change. — yes; this change updates `CLAUDE.md` and the PR template.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/master/LICENSE).

---
_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cmfvui2my5V8gH129xiBKQ)_