### PR TITLE
Improve draft posts: tighten HPC intros, replace 17 placeholder stubs

### DIFF
--- a/content/posts/academic/papers-that-transformed-the-compute-world.md
+++ b/content/posts/academic/papers-that-transformed-the-compute-world.md
@@ -1,10 +1,8 @@
 ---
 title: "Papers that transformed the computer world"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "A tour of the papers that reshaped how we build software — MapReduce, Dynamo, Raft, GFS, the transformer — and what each one actually changed in practice."
 date: 2024-01-10
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Every system we take for granted started as a paper someone had to argue for. MapReduce, Dynamo, Raft, the Google File System, the transformer — a handful of publications reshaped how the entire industry builds software, and reading them is still the fastest way to understand why our systems look the way they do. This is a tour of the papers that transformed computing, and what each one actually changed.

--- a/content/posts/aws/avoid-cfn-init-pitfalls.md
+++ b/content/posts/aws/avoid-cfn-init-pitfalls.md
@@ -1,10 +1,8 @@
 ---
 title: "Avoid cfn-init pitfalls"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "The cfn-init pitfalls that cause silent EC2 bootstrap failures — signal handling, resource ordering, and error propagation — and how to avoid each one."
 date: 2024-01-02
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+`cfn-init` is one of the oldest ways to bootstrap an EC2 instance from CloudFormation, and it is still quietly running in production everywhere. It is also full of sharp edges: silent failures, confusing signal handling, and ordering assumptions that only break under load. Here are the cfn-init pitfalls I keep running into, and how to avoid each one before it costs you a 3 a.m. rollback.

--- a/content/posts/aws/exposing-outputs-in-ssm-automations.md
+++ b/content/posts/aws/exposing-outputs-in-ssm-automations.md
@@ -1,10 +1,8 @@
 ---
 title: "Exposing Outputs in SSM Automations"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "How outputs flow through AWS SSM Automation documents — passing values between steps and surfacing them to callers cleanly, without the usual guesswork."
 date: 2024-01-03
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+SSM Automation documents are excellent at orchestrating multi-step operational tasks — right up until you need to get a value back out of one. Passing outputs between steps, and surfacing them to whatever called the automation, is less obvious than it should be and trips up almost everyone the first time. Here is how outputs actually flow through an SSM Automation, and how to expose the ones you care about cleanly.

--- a/content/posts/hpc/02-why-hpc-matters-a-hands-on-proof.md
+++ b/content/posts/hpc/02-why-hpc-matters-a-hands-on-proof.md
@@ -5,4 +5,4 @@ date: 2024-01-15
 draft: true
 ---
 
-The best way to understand why high-performance computing exists is not to read about it — it is to watch a program transform. In this article we take a single compute-bound workload and push it through ten incremental steps, measuring the wall-clock time after each one.
+The best way to understand why high-performance computing exists is not to read about it — it is to watch a program transform. Take a single compute-bound workload, push it through ten incremental steps, and measure the wall-clock time after each one.

--- a/content/posts/hpc/03-why-hpc-is-the-foundation-of-modern-ai.md
+++ b/content/posts/hpc/03-why-hpc-is-the-foundation-of-modern-ai.md
@@ -5,4 +5,4 @@ date: 2024-02-01
 draft: true
 ---
 
-Every large language model you have ever used was trained on a high-performance computing cluster. That is not a coincidence or a legacy constraint — it is a physical necessity. This article explains why, from first principles.
+Every large language model you have ever used was trained on a high-performance computing cluster. That is not a coincidence or a legacy constraint — it is a physical necessity. Here is why, from first principles.

--- a/content/posts/hpc/04-efa-101.md
+++ b/content/posts/hpc/04-efa-101.md
@@ -5,4 +5,4 @@ date: 2024-02-15
 draft: true
 ---
 
-The network between your compute nodes is not a detail — it is often the bottleneck. Elastic Fabric Adapter is AWS's answer to the latency and bandwidth demands of tightly coupled HPC and AI workloads. This article explains how it works, from the ground up.
+The network between your compute nodes is not a detail — it is often the bottleneck. Elastic Fabric Adapter is AWS's answer to the latency and bandwidth demands of tightly coupled HPC and AI workloads. Here is how it works, from the ground up.

--- a/content/posts/hpc/05-mpi-101.md
+++ b/content/posts/hpc/05-mpi-101.md
@@ -5,4 +5,4 @@ date: 2024-03-01
 draft: true
 ---
 
-MPI is the lingua franca of distributed computing. If you work in HPC, you will encounter it. If you build AI infrastructure at scale, you are already depending on it indirectly through frameworks like NCCL. This article gets you fluent, fast.
+MPI is the lingua franca of distributed computing. If you work in HPC, you will encounter it. If you build AI infrastructure at scale, you already depend on it indirectly through frameworks like NCCL. Time to get fluent.

--- a/content/posts/hpc/07-choosing-the-right-filesystem-for-hpc.md
+++ b/content/posts/hpc/07-choosing-the-right-filesystem-for-hpc.md
@@ -5,4 +5,4 @@ date: 2024-04-01
 draft: true
 ---
 
-Picking the wrong filesystem for an HPC workload is one of the most common and most expensive mistakes in cluster design. The choice directly determines whether your jobs are compute-bound or I/O-bound. This guide gives you the framework to get it right the first time.
+Picking the wrong filesystem for an HPC workload is one of the most common and most expensive mistakes in cluster design. The choice directly determines whether your jobs are compute-bound or I/O-bound. Here is the framework to get it right the first time.

--- a/content/posts/hpc/08-hpc-benchmarking-compute-network-storage.md
+++ b/content/posts/hpc/08-hpc-benchmarking-compute-network-storage.md
@@ -5,4 +5,4 @@ date: 2024-04-15
 draft: true
 ---
 
-Before you run a production workload on a cluster, you should know what that cluster is actually capable of. Benchmarking is not optional — it is how you detect misconfigured hardware, validate network fabric, and establish the baseline you will need when something goes wrong in production.
+Before you run a production workload on a cluster, know what that cluster is actually capable of. Benchmarking is not optional — it is how you detect misconfigured hardware, validate network fabric, and establish the baseline you will need when something goes wrong in production.

--- a/content/posts/hpc/10-hpc-in-the-cloud-state-of-the-art.md
+++ b/content/posts/hpc/10-hpc-in-the-cloud-state-of-the-art.md
@@ -5,4 +5,4 @@ date: 2024-05-15
 draft: true
 ---
 
-The HPC cloud market has matured rapidly. All three major providers now offer purpose-built HPC instances, high-bandwidth networking fabrics, and managed cluster orchestration. But the differences between them are real, consequential, and poorly documented outside of vendor marketing. This article fixes that.
+The HPC cloud market has matured rapidly. All three major providers now offer purpose-built HPC instances, high-bandwidth networking fabrics, and managed cluster orchestration. But the differences between them are real, consequential, and poorly documented outside of vendor marketing.

--- a/content/posts/hpc/11-hpc-on-aws-parallelcluster-vs-pcs-vs-hyperpod-vs-eks.md
+++ b/content/posts/hpc/11-hpc-on-aws-parallelcluster-vs-pcs-vs-hyperpod-vs-eks.md
@@ -5,4 +5,4 @@ date: 2024-06-01
 draft: true
 ---
 
-AWS offers four distinct ways to run HPC workloads in the cloud, and the right choice depends on factors that vendor documentation rarely addresses directly: operational maturity, team size, workload variability, and how much scheduler control you actually need. This article gives you a clear map.
+AWS offers four distinct ways to run HPC workloads in the cloud, and the right choice depends on factors that vendor documentation rarely addresses directly: operational maturity, team size, workload variability, and how much scheduler control you actually need.

--- a/content/posts/hpc/12-cost-anatomy-1000-gpu-training-run-aws.md
+++ b/content/posts/hpc/12-cost-anatomy-1000-gpu-training-run-aws.md
@@ -5,4 +5,4 @@ date: 2024-06-15
 draft: true
 ---
 
-Running a thousand GPUs for days is expensive in ways that are not always obvious from the pricing page. Instance hours are only the beginning. This article builds a complete cost model from first principles and shows where the real money goes — and where to find it again.
+Running a thousand GPUs for days is expensive in ways that are not always obvious from the pricing page. Instance hours are only the beginning. A cost model built from first principles shows where the real money goes — and where to find it again.

--- a/content/posts/hpc/13-slurm-101.md
+++ b/content/posts/hpc/13-slurm-101.md
@@ -5,4 +5,4 @@ date: 2024-07-01
 draft: true
 ---
 
-SLURM is the job scheduler running the majority of the world's HPC clusters. Whether you are a researcher submitting your first batch job or an engineer deploying a training cluster, understanding SLURM is non-negotiable. This article gets you operational from scratch.
+SLURM is the job scheduler running the majority of the world's HPC clusters. Whether you are a researcher submitting your first batch job or an engineer deploying a training cluster, understanding SLURM is non-negotiable. Here is how to get operational from scratch.

--- a/content/posts/hpc/14-fine-tuning-slurm-for-maximum-performance.md
+++ b/content/posts/hpc/14-fine-tuning-slurm-for-maximum-performance.md
@@ -5,4 +5,4 @@ date: 2024-07-15
 draft: true
 ---
 
-A default SLURM installation will schedule jobs. A well-tuned SLURM installation will maximize cluster utilization, enforce resource fairness, and protect node integrity under adversarial workloads. The gap between the two is significant, and this article closes it.
+A default SLURM installation will schedule jobs. A well-tuned SLURM installation will maximize cluster utilization, enforce resource fairness, and protect node integrity under adversarial workloads. The gap between the two is significant.

--- a/content/posts/hpc/16-gpu-memory-hierarchy-hbm-l2-sram.md
+++ b/content/posts/hpc/16-gpu-memory-hierarchy-hbm-l2-sram.md
@@ -5,4 +5,4 @@ date: 2024-08-15
 draft: true
 ---
 
-GPU performance is a memory problem as much as a compute problem. The roofline model tells you whether your kernel is compute-bound or memory-bound, but only if you understand the hierarchy it is rooflined against. This article gives you that understanding.
+GPU performance is a memory problem as much as a compute problem. The roofline model tells you whether your kernel is compute-bound or memory-bound — but only if you understand the hierarchy it is rooflined against.

--- a/content/posts/hpc/17-llm-serving-infrastructure-training-to-inference.md
+++ b/content/posts/hpc/17-llm-serving-infrastructure-training-to-inference.md
@@ -5,4 +5,4 @@ date: 2024-09-01
 draft: true
 ---
 
-Training a large language model and serving it are fundamentally different infrastructure problems. The cluster that minimizes training time is rarely the fleet that minimizes inference cost. This article maps the transition and the decisions that shape it.
+Training a large language model and serving it are fundamentally different infrastructure problems. The cluster that minimizes training time is rarely the fleet that minimizes inference cost.

--- a/content/posts/hpc/18-fine-tuning-llms-on-a-budget-lora-fsx.md
+++ b/content/posts/hpc/18-fine-tuning-llms-on-a-budget-lora-fsx.md
@@ -5,4 +5,4 @@ date: 2024-09-15
 draft: true
 ---
 
-Fine-tuning a large language model does not require a thousand GPUs or a six-figure cloud bill. With the right combination of parameter-efficient techniques and storage architecture, meaningful fine-tuning is within reach for teams of any size. This article shows exactly how.
+Fine-tuning a large language model does not require a thousand GPUs or a six-figure cloud bill. With the right combination of parameter-efficient techniques and storage architecture, meaningful fine-tuning is within reach for teams of any size.

--- a/content/posts/leadership/how-to-manage-your-time.md
+++ b/content/posts/leadership/how-to-manage-your-time.md
@@ -1,10 +1,8 @@
 ---
 title: "How to manage your time"
-description: "In this post I'll share how to manage your time"
+description: "Managing time as an engineer — spending finite attention on the work that matters, and the handful of practices that survive contact with real deadlines."
 date: 2024-01-05
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Time is the one resource an engineer cannot scale, cache, or provision more of. Every productivity system eventually collides with that fact, which is why the goal is not to do more — it is to spend your finite attention on the work that actually moves things. Here is how I think about managing time as an engineer, and the handful of practices that survived contact with real deadlines.

--- a/content/posts/leadership/meetings-for-software-engineers.md
+++ b/content/posts/leadership/meetings-for-software-engineers.md
@@ -1,10 +1,8 @@
 ---
-title: "Meetings for software engineer"
-description: "In this post I'll share how to manage meetings for software engineers"
+title: "Meetings for software engineers"
+description: "Meetings are a coordination tool, not an interruption to endure. How engineers can tell a useful meeting from a wasteful one — and make their own worth the time."
 date: 2024-01-08
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Most engineers treat meetings as the opposite of work — an interruption to endure between the real thing. That instinct is understandable and mostly wrong. A well-run meeting is a coordination tool that saves far more engineering time than it costs; a badly-run one quietly burns the most expensive hours your team has. Here is how to tell them apart, and how to make the meetings you attend worth the calendar space.

--- a/content/posts/my-projects/cli-wizard.md
+++ b/content/posts/my-projects/cli-wizard.md
@@ -1,10 +1,8 @@
 ---
-title: "ParallelCluster Configurations"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+title: "CLI Wizard"
+description: "CLI Wizard generates a modern, pip-installable Python command-line client from any OpenAPI v3 spec — command grouping, help, and credential handling included."
 date: 2024-01-11
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Every REST API deserves a good command-line client, and almost none of them get one — because writing a CLI by hand is repetitive work that goes stale the moment the API changes. I built CLI Wizard to remove that work: point it at an OpenAPI v3 specification and it generates a modern, pip-installable Python CLI, complete with command grouping, help text, and credential handling. Here is how it works, and why I built it.

--- a/content/posts/my-projects/markov-solver.md
+++ b/content/posts/my-projects/markov-solver.md
@@ -1,10 +1,8 @@
 ---
-title: "ParallelCluster Configurations"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+title: "Markov Solver"
+description: "Markov Solver computes steady-state probabilities for discrete-time Markov chains from a YAML definition — symbolic or constant rates, with Graphviz visualization."
 date: 2024-01-11
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Markov chains are simple to describe and tedious to solve by hand — and genuinely painful once the transition rates are symbolic rather than fixed. I built Markov Solver to close that gap: define a chain in YAML, with constant or symbolic rates, and get back steady-state probabilities to twelve decimal places, a Graphviz diagram, and CSV output. Here is what it does and how I use it.

--- a/content/posts/my-projects/nameping.md
+++ b/content/posts/my-projects/nameping.md
@@ -1,10 +1,8 @@
 ---
-title: "ParallelCluster Configurations"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+title: "Nameping"
+description: "Nameping checks a name's availability in one command — batch WHOIS across TLDs plus business-registry lookups, output as JSON, YAML, CSV, or markdown."
 date: 2024-01-11
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Naming a project is the fun part. Finding out whether the name is actually free — across every relevant domain extension and business registry — is the tedious part that usually kills the momentum. I built Nameping to do that check in a single command: batch WHOIS lookups across TLDs and company-registry searches, with results in whatever format you need. Here is how it works.

--- a/content/posts/my-projects/parallelcluster-configurations.md
+++ b/content/posts/my-projects/parallelcluster-configurations.md
@@ -1,10 +1,8 @@
 ---
 title: "ParallelCluster Configurations"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "A collection of annotated AWS ParallelCluster configurations for common HPC scenarios — scheduler, networking, storage, and scaling, with the reasoning behind each."
 date: 2024-01-11
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+AWS ParallelCluster gives you an HPC cluster from a single YAML file — which is exactly why that file is where every real decision lives. Scheduler, networking, storage, instance selection, scaling policy: get them right and the cluster disappears into the background; get them wrong and you pay for it in every job. This is a collection of ParallelCluster configurations for common HPC scenarios, with the reasoning behind each choice.

--- a/content/posts/security/securing-terraform-state.md
+++ b/content/posts/security/securing-terraform-state.md
@@ -1,10 +1,8 @@
 ---
 title: "Securing Terraform state"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "Terraform state holds secrets in plaintext. How to store, encrypt, lock, and access-control remote state so it stops being the weakest link in your IaC."
 date: 2024-01-13
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Terraform state is the most sensitive file in your infrastructure repository, and the one most likely to be mishandled. It holds resource identifiers, connection strings, and — despite every warning — plaintext secrets. Leave it on a laptop or in an unencrypted bucket and you have handed an attacker a map of everything you run. Here is how to store, encrypt, and lock Terraform state so it stops being your weakest link.

--- a/content/posts/security/stig-compliance.md
+++ b/content/posts/security/stig-compliance.md
@@ -1,10 +1,8 @@
 ---
 title: "STIG compliance"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "Approaching DISA STIG hardening as an engineering problem — automating hundreds of controls into a repeatable, auditable process instead of manual checklists."
 date: 2024-01-14
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+STIGs — Security Technical Implementation Guides — are the US Department of Defense's hardening baselines, and they are as thorough as they are unforgiving. Meeting them by hand is a losing game: hundreds of controls per system, each with its own check and fix. Here is how to treat STIG compliance as an engineering problem — automated, repeatable, and auditable — instead of a spreadsheet you dread.

--- a/content/posts/web-applications/authentication-in-spring.md
+++ b/content/posts/web-applications/authentication-in-spring.md
@@ -1,10 +1,8 @@
 ---
 title: "JWT Authentication in Spring"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "How to build JWT-based authentication in Spring — signing, validation, expiry, and the token-handling mistakes that quietly weaken stateless APIs."
 date: 2024-01-07
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Authentication is where most Spring applications first meet real security requirements — and where the most avoidable mistakes get made. JWTs are the default answer for stateless APIs, but a token is only as strong as the way you sign, validate, and expire it. Here is how to build JWT authentication in Spring that holds up outside a tutorial.

--- a/content/posts/web-applications/authorization-in-spring.md
+++ b/content/posts/web-applications/authorization-in-spring.md
@@ -1,10 +1,8 @@
 ---
 title: "Authorization in Spring"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "Role-based and expression-based authorization in Spring Security — method-level checks, role hierarchies, and keeping access rules legible as an app grows."
 date: 2024-01-01
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Authentication tells you who a user is. Authorization decides what they are allowed to do — and it is the half that quietly accumulates bugs as an application grows. Spring Security gives you method-level checks, role hierarchies, and expression-based rules; the skill is choosing the right layer for each decision. Here is how to keep authorization enforceable and legible as your app scales.

--- a/content/posts/web-applications/observability-stack-for-web-applications.md
+++ b/content/posts/web-applications/observability-stack-for-web-applications.md
@@ -1,10 +1,8 @@
 ---
 title: "MySQL Metrics on Grafana"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "Wiring MySQL internal metrics into a Grafana dashboard — connections, buffer pool, throughput, and replication lag — and reading the signals that predict trouble."
 date: 2024-01-09
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+A database that looks healthy from the application side can be one slow query away from trouble. MySQL exposes a wealth of internal metrics — connections, buffer pool usage, query throughput, replication lag — and Grafana turns them into a dashboard you can actually reason about. Here is how to wire MySQL metrics into Grafana and read the signals that matter before they become incidents.

--- a/content/posts/web-applications/securing-secrets-in-spring.md
+++ b/content/posts/web-applications/securing-secrets-in-spring.md
@@ -1,10 +1,8 @@
 ---
 title: "Securing Secrets in Spring"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "Keeping credentials out of source and out of logs in Spring — externalized configuration, a real secrets backend, and the leaks that happen by default."
 date: 2024-01-12
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Secrets in a Spring application have a way of ending up exactly where they should not: in `application.properties`, in environment variables dumped at startup, in a Git history nobody wants to rewrite. Keeping credentials out of source and out of reach takes deliberate design, not good intentions. Here is how to manage secrets in Spring with a real secrets backend instead of hope.

--- a/content/posts/web-applications/storing-uuid-in-spring.md
+++ b/content/posts/web-applications/storing-uuid-in-spring.md
@@ -1,10 +1,8 @@
 ---
 title: "Storing UUID in Spring"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "Storing UUIDs efficiently in Spring and JPA — binary vs. character columns, index cost, and why the obvious VARCHAR mapping quietly taxes performance."
 date: 2024-01-15
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+A UUID is sixteen bytes, but store it carelessly and it costs you far more — in index size, in query latency, in storage wasted across millions of rows. How you map a UUID between Java, JPA, and the database column decides whether it is a clean primary key or a silent performance tax. Here is how to store UUIDs in Spring the efficient way, and why the obvious approach is rarely the right one.

--- a/content/posts/web-applications/throttling-in-spring.md
+++ b/content/posts/web-applications/throttling-in-spring.md
@@ -1,10 +1,8 @@
 ---
 title: "Throttling in Spring"
-description: "In this post I'll share how to avoid cfn-init pitfalls"
+description: "Adding rate limiting to Spring applications — per-client limits, token-bucket strategies, and distributed throttling that survives more than one instance."
 date: 2024-01-16
 draft: true
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Relative link: [Hugo Showcase]({{< ref "posts/hugo-showcase.md" >}})
+Every endpoint you expose is a resource someone can exhaust — deliberately or by accident. Rate limiting is how you protect a service from its own callers without degrading the experience for the well-behaved majority. Here is how to add throttling to a Spring application, from simple per-client limits to distributed rate limiting that survives more than one instance.


### PR DESCRIPTION
### Description of changes

Reviewed every post currently in `draft: true` state and improved each — shorter where there was fat, direct, and in the blog's self-confident-but-friendly voice.

**HPC series (14 of 19 posts) — tightened existing intros.** Cut the meta "This article… / In this article we…" scaffolding and preferred direct, active phrasing (a confident writer states the thing rather than announcing they will). Removed the `we` in favor of `you`/imperative per the content style guide. Left the 5 intros that were already tight and meta-free unchanged (`01`, `06`, `09`, `15`, `19` — these are the exemplar openers quoted in `content/CLAUDE.md`).

**17 non-HPC posts — replaced placeholder stubs with real drafts.** These were identical Lorem ipsum with copy-pasted front matter. Each now has:
* a real opening paragraph in the blog's voice;
* an accurate meta `description` (all 17 previously read *"how to avoid cfn-init pitfalls"*);
* the boilerplate `[Hugo Showcase]` link removed.

Also corrected broken titles: `cli-wizard`, `markov-solver`, and `nameping` all wrongly carried the *"ParallelCluster Configurations"* title; *"Meetings for software engineer"* → *"engineers"*. The four `my-projects` intros are grounded in what each tool actually does (verified against their repos). All posts remain `draft: true`.

### Tests
* Changes are limited to Markdown front matter and body prose under `content/` — no template, config, or asset changes.
* Leaving `make prod` validation to the CI/CD workflow.
* No rendered-website screenshots: all touched posts are drafts, excluded from the production build.

### References
* N/A — no related issues or PRs.
* Voice/tone and content conventions: `content/CLAUDE.md`.

### Checklist
- Pointing to the `master` branch.
- Commit messages describe what and why.
- `make prod` build validation delegated to CI (drafts are excluded from the prod build).
- Documentation not impacted.


---
_Generated by [Claude Code](https://claude.ai/code/session_013zxsZegpHS3WWrJbwgnT77)_