### PR TITLE
Update short subtitle to 'Sr Software Engineer @ AWS'

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ outputs:
 params:
   author: Giacomo Marciani
   description: Senior Software Engineer @ Amazon Web Services
-  descriptionShort: Software Engineer @ AWS
+  descriptionShort: Sr Software Engineer @ AWS
   ogLocale: en_US
   copyrightYear: 2026
   keywords: [software, engineering, giacomo, marciani]


### PR DESCRIPTION
The small-screen subtitle (shown at viewport width <= 1200px) read
'Software Engineer @ AWS', dropping the seniority. Update descriptionShort
to 'Sr Software Engineer @ AWS' to match the full-width version.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0166JqEeTugAM8huVSuWbQuL