### PR TITLE
Point default-branch references at main; keep docs branch-agnostic

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@
 - Check if documentation is impacted by this change.
 
 By submitting this pull request, I confirm that my contribution is compliant with
-the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/master/LICENSE).
+the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/main/LICENSE).
 
 ---
 _This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@
 - Check if documentation is impacted by this change.
 
 By submitting this pull request, I confirm that my contribution is compliant with
-the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/main/LICENSE).
+the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).
 
 ---
 _This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 # Cancel in-progress runs for the same PR when new commits are pushed.
 concurrency:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: 🚀 Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/labels.yaml
       - .github/workflows/sync-labels.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Detailed content-authoring guidance — post structure, quoting posts, and the b
 
 ## Deployment
 
-GitHub Actions (`.github/workflows/deploy.yaml`) deploys to GitHub Pages on push to `main`: installs Hugo extended + Node + ImageMagick + Dart Sass, runs `make build` then `make prod`, and publishes `public/`. Base URL comes from the `BASE_URL` env var (defaults to `https://gmarciani.github.io/`).
+GitHub Actions (`.github/workflows/deploy.yaml`) deploys to GitHub Pages on push to the default branch: installs Hugo extended + Node + ImageMagick + Dart Sass, runs `make build` then `make prod`, and publishes `public/`. Base URL comes from the `BASE_URL` env var (defaults to `https://gmarciani.github.io/`).
 
 ## Pull requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Detailed content-authoring guidance — post structure, quoting posts, and the b
 
 ## Deployment
 
-GitHub Actions (`.github/workflows/deploy.yaml`) deploys to GitHub Pages on push to `master`: installs Hugo extended + Node + ImageMagick + Dart Sass, runs `make build` then `make prod`, and publishes `public/`. Base URL comes from the `BASE_URL` env var (defaults to `https://gmarciani.github.io/`).
+GitHub Actions (`.github/workflows/deploy.yaml`) deploys to GitHub Pages on push to `main`: installs Hugo extended + Node + ImageMagick + Dart Sass, runs `make build` then `make prod`, and publishes `public/`. Base URL comes from the `BASE_URL` env var (defaults to `https://gmarciani.github.io/`).
 
 ## Pull requests
 


### PR DESCRIPTION
### Description of changes

The default branch was renamed from `master` to `main`. This updates the in-repo references, and keeps the **documentation** references branch-agnostic so a future rename won't break them again.

**Workflow triggers — pinned to the literal branch (they require a concrete name):**
* `.github/workflows/cicd.yaml` — `pull_request` branch trigger `master` → `main`.
* `.github/workflows/deploy.yaml` — `push` branch trigger `master` → `main` (deploy-to-Pages trigger).
* `.github/workflows/sync-labels.yaml` — `push` branch trigger `master` → `main`.

**Documentation — no hardcoded branch name:**
* `CLAUDE.md` — deployment note now reads "on push to the default branch" instead of naming a branch.
* `.github/PULL_REQUEST_TEMPLATE.md` — LICENSE link points at `blob/HEAD/LICENSE`; GitHub resolves `HEAD` to the current default branch.

Left `uses: b4b4r07/github-labeler@master` in `sync-labels.yaml` untouched — that pins the external action's own branch, not this repository's default.

### Tests
* Changes are limited to workflow branch triggers, one doc link, and one doc sentence — no site content, templates, or assets touched.
* `make prod` build behavior is unaffected; CI will confirm.
* Functional validation is on GitHub itself: the deploy workflow now fires on pushes to `main`, and this PR targeting `main` exercises the updated CI/CD trigger.

### References
* Follow-up to the branch rename (`master` → `main`).

### Checklist
- Pointing to the `main` branch.
- Commit messages describe what and why.
- Website build is unaffected (`make prod`); no content changes.
- Documentation updated and kept branch-agnostic (`CLAUDE.md`, PR template).
