### PR TITLE
ci(labels): add emoji prefixes to labeler and sync-labels workflow names

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,5 +1,5 @@
 # This workflow assigns labels to PRs according to the rules defined in .github/labeler.yaml.
-name: PR Labeler
+name: 🏷️ PR Labeler
 
 on:
   - pull_request_target

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,4 +1,4 @@
-name: Sync Labels
+name: 🔄 Sync Labels
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Description of changes
* Rename the `PR Labeler` workflow to **🏷️ PR Labeler** and the `Sync Labels` workflow to **🔄 Sync Labels**.
* This matches the emoji naming convention already used by the 🚀 Deploy workflow, making workflow runs easier to distinguish at a glance in the Actions tab.
* No behavioral change: only the two `name:` lines are modified.

### Tests
* YAML syntax of both workflow files validated locally.
* No rendered-website impact; `make prod` is unaffected since only workflow metadata changes.

### References
* Follows up on the emoji naming introduced for the Deploy workflow (`ci(deploy): Update workflow name with emoji prefix`).

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).

---
_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._