### PR TITLE
chore(gitignore): ignore local editorial plan ROADMAP.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ package-lock.json
 .DS_Store
 .hugo_build.lock
 .vscode
+ROADMAP.md


### PR DESCRIPTION
### Description of changes
* Add `ROADMAP.md` to `.gitignore`. It holds the local editorial plan for upcoming posts; working material, not site content, so it stays out of version control.

### Tests
* `git check-ignore -v ROADMAP.md` reports the new rule; the file no longer appears in `git status`.
* No rendered-website impact; `make prod` is unaffected.

### References
* None.

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).

---
_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._