### PR TITLE
docs(claude): restore writing-style rules and fix stale reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Detailed content-authoring guidance — post structure, quoting posts, and the b
 - New posts default to `draft: true` (`archetypes/default.md`). **Drafts are excluded from `make prod`**, so a draft post also stays out of the sitemap and `llms.txt` until published.
 - Cross-references use the `{{< ref "posts/....md" >}}` shortcode.
 - Front matter: `title`, `description` (drives meta/OG/JSON-LD/llms.txt — keep under ~160 chars), `date` (YYYY-MM-DD), `draft`, optional `categories`/`tags`/`image`.
-- "Quoting" posts are short blockquote posts filed under the **topic's** category (not a "quoting" category) — see `structure.md` for the exact title/slug/body format.
+- "Quoting" posts are short blockquote posts filed under the **topic's** category (not a "quoting" category) — see `content/CLAUDE.md` for the exact title/slug/body format.
 
 ## Deployment
 

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -65,7 +65,7 @@ Direct, confident, practitioner-first. Write as an engineer explaining to a peer
 ### Sentence style
 
 - Favor short, declarative sentences. Let the ideas carry the weight.
-- Use em dashes for asides and emphasis — a signature of the voice.
+- NEVER use em dashes (" — " or " -- "). Use a semicolon followed by a space ("; ") for asides and clarifications, or restructure into two sentences.
 - Use repetition with variation; parallel structure drives points home.
 - Avoid filler: "basically", "simply", "just", "actually", "really".
 - Don't start paragraphs with "So," or "Now,".
@@ -86,10 +86,59 @@ Direct, confident, practitioner-first. Write as an engineer explaining to a peer
 
 > "GPU performance is a memory problem as much as a compute problem."
 
+> "Running a thousand GPUs for days is expensive in ways that are not always obvious from the pricing page."
+
+> "After years of building and operating HPC clusters for AI workloads, the same mistakes appear with remarkable consistency."
+
+### Dry humor and vivid analogies (own posts)
+
 > "A cluster with fast GPUs and a slow network is a collection of expensive space heaters."
+
+> "That is the sticker price. It is also the number that most cost estimates stop at. They should not."
+
+### Precise, no-nonsense explanations (own posts)
+
+> "The key word is 'useful.' A weather forecast that takes three days to compute is worthless."
+
+> "NCCL works out of the box, which is both its strength and its trap."
+
+### Brooker-style: building an argument through careful, layered reasoning
+
+> State a cost or tradeoff plainly, then immediately explore what it means in practice. Don't just describe; reason through the implications. Use phrases like "This makes sense: ..." or "The problem is that ..." to guide the reader through your thinking.
+
+> Acknowledge complexity honestly: "The future is harder to see than ever. But let's peer forward and see as best we can."
+
+> Use parallel structure to frame choices: present two roads, two approaches, two outcomes; then let the reader see which one you'd pick and why.
+
+### Steinberger-style: personal conviction and builder energy
+
+> Let genuine enthusiasm show when writing about things you've built or believe in. Not hype; earned excitement from someone who has done the work.
+
+> Be direct about personal motivations: "What I want is to change the world, not build a large company."
+
+> Share the human side of engineering decisions; the tradeoffs aren't just technical, they're personal.
+
+### Fowler-style: clarifying through precise definitions and named patterns
+
+> Start by acknowledging that a term is overloaded or misunderstood, then offer a sharper definition. Use that definition as the foundation for the rest of the argument.
+
+> Name the forces at play. When a tradeoff exists, give each side a label so the reader can reason about it: "internal quality vs. delivery speed" rather than vague gestures at complexity.
+
+> Use diagrams of cause and effect in prose form; show how one decision leads to a consequence, which creates a new constraint, which demands a new decision. Make the chain of reasoning visible.
+
+> Reframe common beliefs: "We are used to something that is 'high quality' as something that costs more. For architecture, this relationship is reversed."
+
+> Prefer evolutionary framing; good architecture supports change over time, not just correctness at a point in time.
+
+### Practitioner authority: speaking from experience (own posts)
+
+> "I'm a full-cycle engineer: I design it, build it, secure it, ship it, and carry the pager for it."
+
+> "They are not exotic. They are not the result of carelessness. They are the predictable consequence of applying general-purpose cloud thinking to a domain with very different constraints."
 
 ### What to avoid
 
+- Em dashes (" — ", " -- ") in any form. Use semicolons or separate sentences instead.
 - Marketing language, hype, or superlatives ("revolutionary", "game-changing", "best-in-class").
 - Passive voice when active is clearer. Prefer "NCCL detects the topology" over "the topology is detected by NCCL".
 - Rhetorical questions as section openers. State the point directly.


### PR DESCRIPTION
### Description of changes
* Restore the **"never use em dashes"** rule in `content/CLAUDE.md`; the condensed writing-style section introduced on `main` had inverted it ("Use em dashes — a signature of the voice"), contradicting the steering guidance the section was derived from.
* Re-add the tone-example subsections that were dropped in the condensation: strong openers, dry humor, precise explanations, Brooker/Steinberger/Fowler style patterns, and practitioner-authority quotes. Example quotes from published posts keep their original em dashes because they document existing text; the rule governs new prose.
* Fix a stale reference in the root `CLAUDE.md`: the quoting-post format now points to `content/CLAUDE.md` instead of the deleted `.kiro/steering/structure.md`.

### Tests
* Documentation-only change; no build or rendered-website impact.

### References
* Supersedes the guidance previously in `.kiro/steering/writing-style.md`, removed on `main`.

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).

---
_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._