### PR TITLE
docs(content): draft all articles except the Hugo showcase

### DIFF
--- a/content/posts/ai/quoting-antirez-on-ai.md
+++ b/content/posts/ai/quoting-antirez-on-ai.md
@@ -1,7 +1,7 @@
 ---
 title: "Quoting antirez on AI"
 date: 2026-04-27
-draft: false
+draft: true
 ---
 
 > Anyway, back to programming. I have a single suggestion for you, my friend. Whatever you believe about what the Right Thing should be, you can't control it by refusing what is happening right now. Skipping AI is not going to help you or your career. Think about it. Test these new tools, with care, with weeks of work, not in a five minutes test where you can just reinforce your own beliefs. Find a way to multiply yourself, and if it does not work for you, try again every few months.

--- a/content/posts/hello-world.md
+++ b/content/posts/hello-world.md
@@ -2,7 +2,7 @@
 title: "Hello, World"
 description: "Welcome to my blog, a space for software engineering, HPC and personal projects."
 date: 2026-04-30
-draft: false
+draft: true
 categories: ["Blog"]
 ---
 

--- a/content/posts/my-projects/cli-wizard.md
+++ b/content/posts/my-projects/cli-wizard.md
@@ -2,7 +2,7 @@
 title: "Personal Project: CLI Wizard"
 description: "Generate modern Python CLIs from OpenAPI specifications. Why I built CLI Wizard, how it works, and how to use it."
 date: 2025-02-08
-draft: false
+draft: true
 ---
 
 Every team that builds an API eventually needs a CLI for it. Not a curl wrapper, not a Postman collection — a real CLI that operators and developers can use in scripts, pipelines, and terminals without thinking twice. The problem is that writing a good CLI is tedious. You end up hand-coding argument parsers, help strings, HTTP calls, error handling, and output formatting for every single endpoint. When the API changes, the CLI drifts. The spec says one thing, the CLI does another, and nobody notices until something breaks.

--- a/content/posts/my-projects/landbourse-cicd.md
+++ b/content/posts/my-projects/landbourse-cicd.md
@@ -2,7 +2,7 @@
 title: "Personal Project: CI/CD for Landbourse"
 description: "How I implemented CI/CD for Landbourse using GitHub Workflows to validate the full-stack build and deploy to Railway."
 date: 2026-04-30
-draft: false
+draft: true
 ---
 
 Landbourse is a dockerized monorepo with 14 services: a React frontend, a FastAPI backend, a PostgreSQL database, a Redis cache, an ARQ worker, MinIO object storage, and a full observability stack with Grafana, InfluxDB, Telegraf, and Loki. Every service has its own Dockerfile, its own environment files, and its own health checks. Deploying this by hand is not an option.

--- a/content/posts/my-projects/markov-solver.md
+++ b/content/posts/my-projects/markov-solver.md
@@ -2,7 +2,7 @@
 title: "Personal Project: Markov Solver"
 description: "Solve discrete-time Markov chains with symbolic transition rates, graph visualization, and multiple input formats. Why I built Markov Solver and how to use it."
 date: 2025-02-08
-draft: false
+draft: true
 ---
 
 During my studies in performance modeling, I spent a lot of time solving Markov chains by hand — setting up balance equations, solving linear systems, checking that probabilities summed to one. The math is straightforward but the bookkeeping is brutal, especially when chains grow beyond a handful of states or when transition rates are symbolic expressions depending on parameters like arrival rates and service rates. I kept making sign errors. I kept losing track of which equations I had already substituted. The frustration was productive — it made me build a tool.


### PR DESCRIPTION
### Description of changes
* Set `draft: true` on every published article except `hugo-showcase`: `cli-wizard`, `markov-solver`, `quoting-antirez-on-ai`, `hello-world`, and `landbourse-cicd`.
* The first two went live unintentionally when #34 was squash-merged just before the revert commit reached its branch; the other three landed published in #34. All of them publish later on their editorial-plan dates instead.
* `content/about.md` stays published (page, not an article), as does `hugo-showcase`.

### Tests
* `draft: true` excludes the posts from `make prod`, the sitemap, and `/llms.txt`; verified flags in front matter.

### References
* Follow-up to #34.

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).

---
_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._