### PR TITLE
docs(about): polish copy and fix style-rule violations

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -6,16 +6,16 @@ type: "about"
 draft: false
 ---
 
-Hi folks, my name is [Giacomo Marciani]({{< ref "about.md" >}}).
-I am a Sr Software Engineer at [Amazon Web Services](https://aws.amazon.com/) with 8+ years of experience in [High Performance Computing](https://en.wikipedia.org/wiki/High-performance_computing). Currently, I work on [AWS ParallelCluster](https://github.com/aws/aws-parallelcluster), a very cool open source project to deploy HPC clusters on AWS.
+Hey, Giacomo here. I'm a full-cycle software engineer: I design it, build it, secure it, ship it, and carry the pager for it.
+I work as a Sr Software Engineer at [Amazon Web Services](https://aws.amazon.com/), where I have been building [High Performance Computing](https://en.wikipedia.org/wiki/High-performance_computing) systems since 2018. Currently, I work on [AWS ParallelCluster](https://github.com/aws/aws-parallelcluster), the open source tool for deploying HPC clusters on AWS.
 
 I have been passionate about computers since I was a little kid. I remember precisely when it started. I was 6 years old, spending a lot of time observing my grandpa doing magic things with a black terminal. One day, he explained to me how the internet works with a simple sketch on a napkin. Everything started that afternoon.
 
-More than anything else, what makes me today a good engineer and a good leader is that I love to design and build software with other people, and I'm never tired of learning something new.
+More than anything else, what makes me a good engineer and leader is that I love building software with other people, and I never stop learning something new.
 
-I come from Rome, spent 6 years living in Sardinia, and I am now based out of Boston. I love travelling, imagining how life would be if I moved to the place I am visiting.
+I come from Rome, spent 6 years living in Sardinia, and I am now based out of Boston. I love traveling, imagining how life would be if I moved to the place I am visiting.
 
-This blog is where I write about the things I care about — HPC architecture, distributed systems, GPU clusters, cloud infrastructure, security, and the human side of engineering: leadership, time management, and building teams that actually enjoy working together.
+This blog is where I write about the things I care about: HPC architecture, distributed systems, GPU clusters, cloud infrastructure, security, and the human side of engineering: leadership, time management, and building teams that actually enjoy working together.
 
 {{< ghactivity username="gmarciani" >}}
 


### PR DESCRIPTION
### Description of changes
* Open with an informal greeting and the practitioner line: "Hey, Giacomo here. I'm a full-cycle software engineer: I design it, build it, secure it, ship it, and carry the pager for it."
* Drop the self-referential name link (it pointed the about page at itself).
* Anchor experience to a year ("since 2018") instead of "8+ years", so the claim doesn't go stale.
* Describe ParallelCluster concretely ("the open source tool for deploying HPC clusters on AWS") instead of "a very cool open source project".
* Replace the body em dash with a colon per the blog's style rules (the front-matter description keeps its em dash intentionally).
* Tighten the engineer-and-leader sentence and switch "travelling" to US spelling.

### Tests
* `make prod` builds successfully on this branch.
* Copy-only change to an existing page; front matter (title, description, image, type) unchanged except body text.

### References
* Style rules: `content/CLAUDE.md` (writing style section).

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).

---
_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._