### PR TITLE
fix(build): generate favicon with ImageMagick 6 or 7

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -305,7 +305,8 @@ gulp.task('images-brand-favicons', function(done) {
   gulp.src(paths.src.images.brand.favicon)
   .pipe(plumber())
   .pipe(shell(
-    'mkdir -p ' + paths.site.images.brand + ' ; magick <%= file.path %> -define icon:auto-resize='
+    // ImageMagick 7 ships `magick`, ImageMagick 6 (Ubuntu apt) only `convert`.
+    'mkdir -p ' + paths.site.images.brand + ' ; im="$(command -v magick || command -v convert)" ; "$im" <%= file.path %> -define icon:auto-resize='
     + icosizes.join(',') + ' '
     + paths.site.images.brand + '/favicon.ico'
   ));


### PR DESCRIPTION
### Description of changes
* The `images-brand-favicons` Gulp task invoked the `magick` binary, which only exists in ImageMagick 7. The deploy workflow installs ImageMagick from apt (version 6, `convert` only), so favicon generation failed with exit 127 on every CI build; `plumber()` swallowed the error, and the deployed site silently used the failover icon instead of a freshly generated `favicon.ico`.
* The command now resolves whichever binary exists (`magick`, falling back to `convert`) before invoking it, so favicon generation works on both the macOS dev machines (IM7) and the Ubuntu runner (IM6).

### Tests
* `make build` locally (IM7): `static/images/brand/favicon.ico` generated, 5 icon sizes.
* Simulated the runner environment by restricting `PATH` to a `convert`-only shim: the fallback resolves `convert` and produces an identical 5-icon ICO.
* After merge, the deploy run's build log should show no `gulp-shell` error in `images-brand-favicons`.

### References
* Surfaced while diagnosing the failed 🚀 Deploy run 29656787403 (the deploy failure itself was the stale `master` branch policy on the `github-pages` environment, fixed separately in repo settings).

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).

---
_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._