### PR TITLE
docs(content): stage the blog launch: welcome post, how-it-is-built post, Sunday schedule

### DIFF
--- a/content/posts/hello-world.md
+++ b/content/posts/hello-world.md
@@ -6,7 +6,7 @@ draft: true
 categories: ["Blog"]
 ---
 
-Welcome! Giacomo here. I'm a full-cycle software engineer: I design it, build it, secure it, ship it, and carry the pager for it. I'm also a guitar player, a 3D printing enthusiast, an avid reader of technical books (even more than novels, guilty as charged), and above all a father of three wonderful kids.
+Welcome! Giacomo here. I'm a full-cycle software engineer: I design it, build it, secure it, ship it, and carry the pager for it. I'm also an amateur guitar player, a 3D printing hobbyist, an avid reader of technical books (even more than novels, guilty as charged), and above all a father of three wonderful kids.
 
 At work, I'm a Senior Software Engineer at AWS, where I've been building high-performance computing systems since 2018: systems that need to scale, stay resilient, and be secure from the ground up. I also love the adrenaline of jumping into critical situations to mitigate and resolve them. Over the years I've picked up a lot of patterns, trade-offs, and hard-won lessons. I share plenty with colleagues, but that only reaches so far. This blog is where I collect those lessons and put them into words: HPC architecture, distributed systems, GPU clusters, cloud infrastructure, security, and the human side of engineering, from leadership and time management to building teams that actually enjoy working together.
 

--- a/content/posts/hello-world.md
+++ b/content/posts/hello-world.md
@@ -6,9 +6,9 @@ draft: true
 categories: ["Blog"]
 ---
 
-Hey there, I'm Giacomo Marciani. Senior Software Engineer in HPC at AWS, guitar player, 3D printing enthusiast, avid reader of technical books (even more than novels, guilty as charged), and above all a father of three wonderful kids.
+Welcome! Giacomo here. I'm a full-cycle software engineer: I design it, build it, secure it, ship it, and carry the pager for it. I'm also a guitar player, a 3D printing enthusiast, an avid reader of technical books (even more than novels, guilty as charged), and above all a father of three wonderful kids.
 
-At work, I've been in high-performance computing since 2018, designing systems that need to scale, stay resilient, and be secure from the ground up. I also love the adrenaline of jumping into critical situations to mitigate and resolve them. Over the years I've picked up a lot of patterns, trade-offs, and hard-won lessons. I share plenty with colleagues, but that only reaches so far. This blog is where I collect those lessons and put them into words: HPC architecture, distributed systems, GPU clusters, cloud infrastructure, security, and the human side of engineering, from leadership and time management to building teams that actually enjoy working together.
+At work, I'm a Senior Software Engineer at AWS, where I've been building high-performance computing systems since 2018: systems that need to scale, stay resilient, and be secure from the ground up. I also love the adrenaline of jumping into critical situations to mitigate and resolve them. Over the years I've picked up a lot of patterns, trade-offs, and hard-won lessons. I share plenty with colleagues, but that only reaches so far. This blog is where I collect those lessons and put them into words: HPC architecture, distributed systems, GPU clusters, cloud infrastructure, security, and the human side of engineering, from leadership and time management to building teams that actually enjoy working together.
 
 In my free time, the kids set the agenda. We travel and explore the United States together. I'm originally from Rome, spent six years in Sardinia, and now call Boston home, so moving around is in my DNA. We also 3D print together, which sits in that sweet spot between engineering and craft.
 

--- a/content/posts/hello-world.md
+++ b/content/posts/hello-world.md
@@ -8,7 +8,7 @@ categories: ["Blog"]
 
 Hey there, I'm Giacomo Marciani. Senior Software Engineer in HPC at AWS, guitar player, 3D printing enthusiast, avid reader of technical books (even more than novels, guilty as charged), and above all a father of three wonderful kids.
 
-At work, I've spent 8+ years in high-performance computing, designing systems that need to scale, stay resilient, and be secure from the ground up. I also love the adrenaline of jumping into critical situations to mitigate and resolve them. Over the years I've picked up a lot of patterns, trade-offs, and hard-won lessons. I share plenty with colleagues, but that only reaches so far. This blog is where I collect and put into words all the cool stuff I learn every day.
+At work, I've been in high-performance computing since 2018, designing systems that need to scale, stay resilient, and be secure from the ground up. I also love the adrenaline of jumping into critical situations to mitigate and resolve them. Over the years I've picked up a lot of patterns, trade-offs, and hard-won lessons. I share plenty with colleagues, but that only reaches so far. This blog is where I collect those lessons and put them into words: HPC architecture, distributed systems, GPU clusters, cloud infrastructure, security, and the human side of engineering, from leadership and time management to building teams that actually enjoy working together.
 
 In my free time, the kids set the agenda. We travel and explore the United States together. I'm originally from Rome, spent six years in Sardinia, and now call Boston home, so moving around is in my DNA. We also 3D print together, which sits in that sweet spot between engineering and craft.
 

--- a/content/posts/how-this-blog-is-built.md
+++ b/content/posts/how-this-blog-is-built.md
@@ -1,0 +1,84 @@
+---
+title: "How this blog is built"
+description: "The software stack behind this blog: Hugo, Pug, SCSS, and a Gulp pipeline, plus the process I use to maintain and publish it."
+date: 2026-08-09
+draft: true
+categories: ["Blog"]
+---
+
+This blog is a static site with a custom theme, and every part of it is code I can read, build, and break. No CMS, no database, no theme marketplace. Markdown goes in, HTML comes out, and everything in between is versioned in a single repository. This post walks through the stack, the build pipeline, and the process I use to keep it alive.
+
+## The stack
+
+The site runs on [Hugo](https://gohugo.io/), the static site generator. The theme is not a stock one: it is compiled from source I maintain in the same repository. [Pug](https://pugjs.org/) templates compile to the HTML layouts Hugo consumes, [SCSS](https://sass-lang.com/) compiles to the stylesheet, and a [Gulp](https://gulpjs.com/) pipeline orchestrates the whole thing: views, styles, scripts, fonts, images, and meta files. Formulas render with MathJax, and icons and social images are generated at build time with ImageMagick.
+
+Hosting is [GitHub Pages](https://pages.github.com/). There is no server to patch and nothing to scale; the heaviest operational burden this blog can produce is a failed build.
+
+## The build pipeline
+
+The build has two stages, and understanding the split explains the whole repository layout:
+
+1. **Gulp** compiles `src/` into the directories Hugo expects: Pug views become HTML layouts, SCSS becomes minified CSS, and fonts, images, and meta files are optimized and copied into place.
+2. **Hugo** combines the Markdown content with the generated layouts and static assets, and produces the final site.
+
+Everything generated is disposable and never edited by hand. The source of truth is only `content/` (the posts) and `src/` (the theme). A `Makefile` wraps the common operations: `make build` compiles assets, `make serve` runs a local server with drafts enabled, and `make prod` produces the minified production build without drafts.
+
+## Deployment
+
+Every push to the main branch triggers a GitHub Actions workflow: it installs Hugo, Node.js, ImageMagick, and Dart Sass, runs the two-stage build, and deploys the result to GitHub Pages. Publishing a post and deploying an infrastructure change are the same operation: a merge.
+
+## The maintenance process
+
+The blog follows an editorial plan: one post every two weeks, published on Sundays. Posts start as drafts; drafts are excluded from the production build, the sitemap, and the feeds, so work in progress never leaks. Publishing a post means setting its date, flipping `draft: false`, and merging; the deploy does the rest.
+
+Every change lands through a pull request, and pre-commit hooks keep the repository honest. The same review discipline I apply to production systems applies here, at a fraction of the stakes; it keeps the muscle trained.
+
+## What Hugo renders
+
+The rest of this post is a live showcase of what the pipeline can render, useful as a self-test after theme changes and as a demonstration of Hugo's shortcodes.
+
+### Links
+
+Cross-references between posts use Hugo's `ref` shortcode, which resolves and validates the target at build time: [Hello, World]({{< ref "posts/hello-world.md" >}}).
+
+### Formulas
+
+$$\int_{a}^{b} x^2 dx$$
+
+### Figures
+
+![Sample Image](/images/posts/sample-image.svg)
+
+### YouTube
+
+{{< youtube OTzTAp-uXgI >}}
+
+### Vimeo
+
+{{< vimeo 70476512 >}}
+
+### Instagram
+
+{{< instagram ChcyFLRtVFv >}}
+
+### X
+
+{{< x user=giacomomarciani id=1247056493712756737 >}}
+
+### Code
+
+```java
+public static void main(String[] args) {
+    System.out.println("Hello world!");
+}
+```
+
+Remote files render through a custom `ghcode` shortcode that embeds source straight from GitHub:
+
+{{< ghcode "https://raw.githubusercontent.com/gmarciani/yawa/mainline/docker-compose.yaml" >}}
+
+### GitHub activity
+
+The contribution chart below comes from a custom `ghactivity` shortcode:
+
+{{< ghactivity username="gmarciani" >}}

--- a/content/posts/hugo-showcase.md
+++ b/content/posts/hugo-showcase.md
@@ -1,9 +1,9 @@
 ---
 title: "Hugo Showcase"
 description: "Insert here the description for post"
-date: 2026-08-09
+date: 2021-09-09
 lastmod: 2024-05-05
-draft: false
+draft: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
### Description of changes
* `hello-world.md`: list the blog's actual topics (same set as the about page), anchor experience to "since 2018", and set `date: 2026-08-02` (Sunday), slot 1 of the editorial plan.
* `how-this-blog-is-built.md` (new): second launch post, dated 2026-08-09 (Sunday). Covers the stack (Hugo, Pug, SCSS, Gulp, GitHub Actions, GitHub Pages), the two-stage build pipeline, and the maintenance process; closes with a live rendering showcase (MathJax formulas, figures, YouTube/Vimeo/Instagram/X embeds, code blocks, the custom `ghcode` shortcode, and the `ghactivity` contribution chart) carried over from the unpublished Hugo showcase.
* `hugo-showcase.md`: set `draft: true`; its rendering-demo role moves into the new post.
* All future publications land on Sundays; the launch posts are one week apart, then the plan continues biweekly (HPC series opener on 2026-08-23).
* **After this merge and deploy, the blog has zero published articles until the welcome post goes live on 2026-08-02** (the about page stays up); this is intentional so the blog launches with the welcome post.

### Tests
* `make prod` builds successfully (26 pages; all three staged posts correctly excluded as drafts).
* `hugo -D -F` renders both launch posts; verified the new post's output contains the ghactivity chart, MathJax, and all embeds.

### References
* Editorial plan: slot 1 Hello World (2026-08-02), slot 2 How this blog is built (2026-08-09), slot 3 HPC series opener (2026-08-23).

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).

---
_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._