### PR TITLE
fix(build): keep the favicon background transparent

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -306,7 +306,8 @@ gulp.task('images-brand-favicons', function(done) {
   .pipe(plumber())
   .pipe(shell(
     // ImageMagick 7 ships `magick`, ImageMagick 6 (Ubuntu apt) only `convert`.
-    'mkdir -p ' + paths.site.images.brand + ' ; im="$(command -v magick || command -v convert)" ; "$im" <%= file.path %> -define icon:auto-resize='
+    // -background none keeps the SVG's transparency instead of flattening onto white.
+    'mkdir -p ' + paths.site.images.brand + ' ; im="$(command -v magick || command -v convert)" ; "$im" -background none <%= file.path %> -define icon:auto-resize='
     + icosizes.join(',') + ' '
     + paths.site.images.brand + '/favicon.ico'
   ));


### PR DESCRIPTION

### Description of changes
* The generated `favicon.ico` rendered as a white square wherever the browser fell back to it instead of the SVG icon: ImageMagick flattens SVG input onto its default white canvas when rasterizing.
* Pass `-background none` when reading `favicon.svg` in the `images-brand-favicons` gulp task, preserving the SVG's transparency in every generated icon size. Works on both ImageMagick 6 (`convert`) and 7 (`magick`).

### Tests
* `make build` regenerates `favicon.ico`; all five frames (16, 24, 32, 48, 64 px) now report `opaque=False` with fully transparent corner pixels (`#00000000`), where the previous file was fully opaque white.
* `make prod` builds successfully.

### References
* None.

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).

---
_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._