### PR TITLE
fix(seo): feed only posts via a custom RSS template

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,7 @@ const paths = {
 
     views     : {
       base    : 'src/views',
-      every   : 'src/views/**/*.{pug,html,txt}'
+      every   : 'src/views/**/*.{pug,html,txt,xml}'
     },
 
     meta     : {
@@ -225,8 +225,8 @@ gulp.task('views', function(done) {
   }))
   .pipe(gulp.dest(paths.site.views.base));
 
-  // Raw Hugo templates passed through verbatim (.html partials, .txt outputs).
-  gulp.src('src/views/**/*.{html,txt}')
+  // Raw Hugo templates passed through verbatim (.html partials, .txt/.xml outputs).
+  gulp.src('src/views/**/*.{html,txt,xml}')
   .pipe(plumber())
   .pipe(gulp.dest(paths.site.views.base));
   done();

--- a/src/views/_default/rss.xml
+++ b/src/views/_default/rss.xml
@@ -1,0 +1,42 @@
+{{- /* Custom RSS: feeds carry only posts (never standalone pages like /about/),
+and item descriptions prefer the curated front-matter description over the
+auto-summary. Based on Hugo's embedded _default/rss.xml. */ -}}
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if $.IsHome -}}
+{{- $pages = where $pctx.RegularPages "Type" "posts" -}}
+{{- else if $.IsSection -}}
+{{- $pages = where $pctx.RegularPagesRecursive "Type" "posts" -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+{{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo</generator>
+    <language>{{ .Site.Language.Locale }}</language>
+    {{- with $pages }}
+    <lastBuildDate>{{ (index . 0).Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{- end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ with .Description }}{{ . | html }}{{ else }}{{ .Summary | html }}{{ end }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>

--- a/src/views/partials/head.pug
+++ b/src/views/partials/head.pug
@@ -11,7 +11,7 @@ meta(name='google' content='notranslate')
 include seo/meta.html
 
 //- FEED & ICONS
-link(rel='alternate' type='application/rss+xml' title='{{ .Site.Title }}' href!='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}')
+link(rel='alternate' type='application/rss+xml' title='{{ .Site.Title }}' href!='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ else }}{{ absURL "index.xml" }}{{ end }}')
 link(rel='icon' type='image/svg+xml' sizes='any' href!='{{ absURL "images/brand/favicon.svg" }}')
 link(rel='icon' type='image/x-icon' href!='{{ absURL "images/brand/favicon.ico" }}')
 link(rel='mask-icon' type='image/svg+xml' href!='{{ absURL "images/brand/mask.svg" }}' color='#10171e')


### PR DESCRIPTION

### Description of changes
* The RSS feeds used Hugo's embedded template, which feeds every regular page: the About page (undated) appeared as a feed item with a year-0001 `pubDate` — on the live site it is currently the *only* feed entry.
* Add a custom `src/views/_default/rss.xml` (passed through to `layouts/` by Gulp, like the existing `.html`/`.txt` templates) that feeds only posts: the home feed filters site pages by type, section feeds use `.RegularPagesRecursive` (the non-recursive default also hid every post nested in a category directory, leaving `/posts/index.xml` with 3 items), and category feeds keep their term pages.
* Feed item descriptions now prefer the curated front-matter `description` (the same field driving meta/OG/JSON-LD), falling back to the auto-summary for posts without one.
* Single pages without an RSS output format now point their `rel=alternate` link at the site feed instead of rendering an empty `href`.

### Tests
* `make build` + `hugo -D -F`: `index.xml` and `posts/index.xml` carry all 42 posts, category feeds their own posts; zero About entries and zero year-0001 dates across all feeds; every feed parses as valid XML with a correct `atom:link` self reference.
* A post with a front-matter description (SLURM 101) shows it verbatim as the item description; a post without one (the antirez quoting post) falls back to its summary.
* A single post page renders `rel=alternate` pointing to `https://gmarciani.github.io/index.xml`.
* `make prod` builds successfully; the production feed is valid XML with an empty channel (correct while all posts are future-dated drafts).

### References
* None.

### Checklist
- Make sure you are pointing to **the right branch**.
- Check all commits' messages are clear, describing what and why vs how.
- Make sure the website **builds successfully** (`make prod`).
- Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).

---
_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._