### PR TITLE
Blog cleanup: five-category taxonomy, content rewrites, and theme fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,3 @@
 
 By submitting this pull request, I confirm that my contribution is compliant with
 the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).
-
----
-_This pull request was created with the assistance of [Claude Code](https://claude.com/claude-code)._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,4 +64,4 @@ GitHub Actions (`.github/workflows/deploy.yaml`) deploys to GitHub Pages on push
 
 ## Pull requests
 
-Every PR **must follow `.github/PULL_REQUEST_TEMPLATE.md`** — mirror its sections (Description of changes, Tests, References, Checklist) and fill each from the actual changes. The template already ends with the "created with the assistance of Claude Code" attribution, so **do not add a second attribution** (no extra "Generated with Claude Code" footer) — keep exactly one, the template's.
+Every PR **must follow `.github/PULL_REQUEST_TEMPLATE.md`** — mirror its sections (Description of changes, Tests, References, Checklist) and fill each from the actual changes. **Never add Claude attribution**: no "Generated with Claude Code" footer, no session id, no session link.

--- a/content/about.md
+++ b/content/about.md
@@ -7,7 +7,7 @@ draft: false
 ---
 
 Hey, Giacomo here. I'm a full-cycle software engineer: I design it, build it, secure it, ship it, and carry the pager for it.
-I work as a Sr Software Engineer at [Amazon Web Services](https://aws.amazon.com/), where I have been building [High Performance Computing](https://en.wikipedia.org/wiki/High-performance_computing) systems since 2018. Currently, I work on [AWS ParallelCluster](https://github.com/aws/aws-parallelcluster), the open source tool for deploying HPC clusters on AWS.
+I work as a Sr Software Engineer at [Amazon Web Services](https://aws.amazon.com/), where I have been building cloud services and [High Performance Computing](https://en.wikipedia.org/wiki/High-performance_computing) systems since 2018. Currently, I work on [AWS ParallelCluster](https://github.com/aws/aws-parallelcluster), the open source tool for deploying HPC clusters on AWS.
 
 I have been passionate about computers since I was a little kid. I remember precisely when it started. I was 6 years old, spending a lot of time observing my grandpa doing magic things with a black terminal. One day, he explained to me how the internet works with a simple sketch on a napkin. Everything started that afternoon.
 
@@ -15,7 +15,7 @@ More than anything else, what makes me a good engineer and leader is that I love
 
 I come from Rome, spent 6 years living in Sardinia, and I am now based out of Boston. I love traveling, imagining how life would be if I moved to the place I am visiting.
 
-This blog is where I write about the things I care about: HPC architecture, distributed systems, GPU clusters, cloud infrastructure, security, and the human side of engineering: leadership, time management, and building teams that actually enjoy working together.
+This blog is where I write about the things I care about: HPC architecture, distributed systems, GPU clusters, cloud infrastructure, automation, security, and the human side of engineering: leadership, time management, and building teams that actually enjoy working together.
 
 {{< ghactivity username="gmarciani" >}}
 

--- a/content/posts/academic/_index.md
+++ b/content/posts/academic/_index.md
@@ -2,5 +2,5 @@
 cascade:
   - target:
       kind: page
-    categories: ["Academic"]
+    categories: ["Software Design"]
 ---

--- a/content/posts/ai/_index.md
+++ b/content/posts/ai/_index.md
@@ -2,5 +2,5 @@
 cascade:
   - target:
       kind: page
-    categories: ["AI"]
+    categories: ["Artificial Intelligence"]
 ---

--- a/content/posts/aws/_index.md
+++ b/content/posts/aws/_index.md
@@ -2,5 +2,5 @@
 cascade:
   - target:
       kind: page
-    categories: ["AWS"]
+    categories: ["Software Design"]
 ---

--- a/content/posts/hello-world.md
+++ b/content/posts/hello-world.md
@@ -1,15 +1,15 @@
 ---
-title: "Hello, World"
-description: "Welcome to my blog, a space for software engineering, HPC and personal projects."
+title: "Hello World"
+description: "Why this blog exists: a place to collect and formalize lessons from HPC, software design, and the daily trade-offs of software engineering."
 date: 2026-08-02
 draft: true
-categories: ["Blog"]
+categories: ["Personal Projects"]
 ---
 
-Welcome! Giacomo here. I'm a full-cycle software engineer: I design it, build it, secure it, ship it, and carry the pager for it. I'm also an amateur guitar player, a 3D printing hobbyist, an avid reader of technical books (even more than novels, guilty as charged), and above all a father of three wonderful kids.
+Welcome! I'm Giacomo, a Senior Software Engineer at [AWS](https://aws.amazon.com/), where I've been building cloud services and high-performance computing systems since 2018. The [about page]({{< ref "about.md" >}}) tells more about myself; this post tells you why this blog exists.
 
-At work, I'm a Senior Software Engineer at AWS, where I've been building high-performance computing systems since 2018: systems that need to scale, stay resilient, and be secure from the ground up. I also love the adrenaline of jumping into critical situations to mitigate and resolve them. Over the years I've picked up a lot of patterns, trade-offs, and hard-won lessons. I share plenty with colleagues, but that only reaches so far. This blog is where I collect those lessons and put them into words: HPC architecture, distributed systems, GPU clusters, cloud infrastructure, security, and the human side of engineering, from leadership and time management to building teams that actually enjoy working together.
+Most of what I've learned lives in my head, scattered in design docs, code and in conversations with colleagues. Knowledge in that state fades, stays fuzzy, and does not travel out of office rooms. Writing fixes these problems: it forces me to name things precisely, identify trade-offs, and challenge assumptions. I write mainly for myself, to formalize what I know and not forget it. If it helps or challenges someone else along the way, even better.
 
-In my free time, the kids set the agenda. We travel and explore the United States together. I'm originally from Rome, spent six years in Sardinia, and now call Boston home, so moving around is in my DNA. We also 3D print together, which sits in that sweet spot between engineering and craft.
+I'll write about high-performance computing, software design, daily trade-offs in software engineering, and my personal projects, typically hosted on [my GitHub](https://github.com/gmarciani).
 
-If any of that sounds interesting, stick around. Plenty more to come.
+Follow me on [Twitter](https://www.twitter.com/giacomomarciani), where I announce every new post.

--- a/content/posts/how-this-blog-is-built.md
+++ b/content/posts/how-this-blog-is-built.md
@@ -39,7 +39,7 @@ The rest of this post is a live showcase of what the pipeline can render, useful
 
 ### Links
 
-Cross-references between posts use Hugo's `ref` shortcode, which resolves and validates the target at build time: [Hello, World]({{< ref "posts/hello-world.md" >}}).
+Cross-references between posts use Hugo's `ref` shortcode, which resolves and validates the target at build time: [Hello World]({{< ref "posts/hello-world.md" >}}).
 
 ### Formulas
 

--- a/content/posts/how-this-blog-is-built.md
+++ b/content/posts/how-this-blog-is-built.md
@@ -3,7 +3,7 @@ title: "How this blog is built"
 description: "The software stack behind this blog: Hugo, Pug, SCSS, and a Gulp pipeline, plus the process I use to maintain and publish it."
 date: 2026-08-09
 draft: true
-categories: ["Blog"]
+categories: ["Personal Projects"]
 ---
 
 This blog is a static site with a custom theme, and every part of it is code I can read, build, and break. No CMS, no database, no theme marketplace. Markdown goes in, HTML comes out, and everything in between is versioned in a single repository. This post walks through the stack, the build pipeline, and the process I use to keep it alive.

--- a/content/posts/hpc/11-hpc-on-aws.md
+++ b/content/posts/hpc/11-hpc-on-aws.md
@@ -1,5 +1,5 @@
 ---
-title: "Running HPC workloads on AWS: ParallelCluster vs. Parallel Computing Service vs. SageMaker HyperPod vs. EKS"
+title: "Running HPC workloads on AWS"
 description: "A side-by-side comparison of provisioning complexity, scheduling model, autoscaling, networking integration, and operational overhead, with a concrete recommendation matrix for choosing the right service."
 date: 2027-04-04
 draft: true

--- a/content/posts/hpc/_index.md
+++ b/content/posts/hpc/_index.md
@@ -2,5 +2,5 @@
 cascade:
   - target:
       kind: page
-    categories: ["HPC"]
+    categories: ["High Performance Computing"]
 ---

--- a/content/posts/my-projects/_index.md
+++ b/content/posts/my-projects/_index.md
@@ -2,5 +2,5 @@
 cascade:
   - target:
       kind: page
-    categories: ["My Projects"]
+    categories: ["Personal Projects"]
 ---

--- a/content/posts/security/_index.md
+++ b/content/posts/security/_index.md
@@ -2,5 +2,5 @@
 cascade:
   - target:
       kind: page
-    categories: ["Security"]
+    categories: ["Software Design"]
 ---

--- a/content/posts/web-applications/_index.md
+++ b/content/posts/web-applications/_index.md
@@ -2,5 +2,5 @@
 cascade:
   - target:
       kind: page
-    categories: ["Web Applications"]
+    categories: ["Software Design"]
 ---

--- a/src/meta/.manifest.json
+++ b/src/meta/.manifest.json
@@ -4,7 +4,7 @@
     "description": "Senior Software Engineer @ Amazon Web Services",
     "start_url": "/",
     "scope": "/",
-    "display": "standalone",
+    "display": "browser",
     "background_color": "#10171e",
     "theme_color": "#10171e",
     "icons": [

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1104,21 +1104,7 @@ article {
   }
 }
 
-.author {
-  float: left;
-}
-
 @media (max-width: 550px) {
-  .author {
-    float: none !important;
-  }
-}
-
-@media (max-width: 550px) {
-  .author {
-    float: none !important;
-  }
-
   .f-post-time {
     float: inherit !important;
   }

--- a/src/views/_default/terms.pug
+++ b/src/views/_default/terms.pug
@@ -2,7 +2,7 @@
 h3 {{ .Title }}
 | {{ $data := .Data }}
 | {{ range $key,$value := .Data.Terms.Alphabetical }}
-a(href!='{{ $.Page.RelPermalink }}{{ $value.Name | urlize }}/') {{ $value.Name }} ({{ $value.Count }})
+a(href!='{{ $.Page.RelPermalink }}{{ $value.Name | urlize }}/') {{ $value.Name }}
 br
 | {{ end }}
 | {{ end }}

--- a/src/views/posts/single.pug
+++ b/src/views/posts/single.pug
@@ -7,23 +7,6 @@ article.posts
     hr
     footer.post-footer
         section.f-1
-            | {{ if isset .Params "author" }}
-            section.author
-                p by [{{ index .Params "author" }}]
-            | {{ else if isset .Site.Params "author" }}
-            section.author
-                p
-                    |By  
-                    a(href!='{{ absURL "about"}}') [{{ index .Site.Params "author" }}]
-            | {{ end }}
-            p.f-post-time
-                |Created  
-                time(datetime!='{{ .Date.Format "2006-01-02t15:04:05z07:00" | safeHTML }}') [{{ .Date.Format "Jan 2, 2006" }}]
-                | {{ if ne .Lastmod .Date }}
-                |, Updated  
-                time(datetime!='{{ .Lastmod.Format "2006-01-02t15:04:05z07:00" | safeHTML }}') [{{ .Lastmod.Format "Jan 2, 2006" }}]
-                | {{ end }}
-        section.f-2
             section.share
                 span
                     | Share:
@@ -33,6 +16,14 @@ article.posts
                         i.fab.fa-twitter
                     a.icon-linkedin(href='https://www.linkedin.com/shareArticle?mini=true&url={{ .Permalink }}&title={{ .Title | htmlEscape }}&summary={{ .Summary | htmlEscape }}&source=LinkedIn' onclick='window.open(this.href, "linkedin-share", "width=490,height=530");return false;')
                         i.fab.fa-linkedin-in
+            p.f-post-time
+                |Created  
+                time(datetime!='{{ .Date.Format "2006-01-02t15:04:05z07:00" | safeHTML }}') [{{ .Date.Format "Jan 2, 2006" }}]
+                | {{ if ne .Lastmod .Date }}
+                |, Updated  
+                time(datetime!='{{ .Lastmod.Format "2006-01-02t15:04:05z07:00" | safeHTML }}') [{{ .Lastmod.Format "Jan 2, 2006" }}]
+                | {{ end }}
+        section.f-2
             | {{ if gt .Params.tags 0 }}
             span.f-post-tags
                 i.fa.fa-tag


### PR DESCRIPTION

### Description of changes

Housekeeping across content, taxonomy, and theme, collecting the work that had accumulated locally on `main`.

**Content**
* Rewrite the Hello World launch post around why the blog exists: formalizing knowledge so it does not fade or stay locked in conversations. Sharpen the topics list and close with the follow links.
* Align the about page: mention cloud services alongside HPC, and add automation to the list of blog topics.
* Shorten the title and slug of the AWS HPC comparison post to `11-hpc-on-aws.md`. The old title spelled out all four services and overflowed post listings and social cards; the comparison already lives in the description.
* Fix the Hello World cross-reference label in the showcase post, which still carried the old comma.

**Taxonomy**
* Consolidate nine categories into the five the blog actually advertises: High Performance Computing, Artificial Intelligence, Software Design, Leadership, Personal Projects. `HPC`, `AI` and `My Projects` are renamed to their full names; `Academic`, `AWS`, `Security` and `Web Applications` fold into `Software Design`.
* Categories are set by the per-directory `cascade` in each `_index.md`, so no post moved and no post URL changed.

**Theme**
* Remove the per-term post counters from the taxonomy pages; category and tag links now render plain.
* Replace the redundant "By Giacomo Marciani" post-footer line with the share links, and drop the now-unused `.author` styles.
* Stop declaring the blog as an installable app: the manifest used `display: standalone`, which was enough for Chrome to prompt visitors to install the site. `display: browser` keeps the theme colour and icon metadata without the prompt.

**Repo**
* Drop the "created with the assistance of Claude Code" footer from the PR template, and update `CLAUDE.md` to match.

### Tests

* `make prod` builds successfully from a clean `public/`: 26 pages, drafts excluded.
* `make build` followed by `hugo -D -F` builds successfully, and `/categories/` renders exactly the five categories above with no post counters.
* Confirmed the taxonomy change touches only `_index.md` cascade blocks, so post paths and URLs are unchanged.
* No screenshots attached. The visible changes are the categories page and the post footer; happy to add captures if useful.

### References

* No related open issues.

### Checklist

- [x] Pointing at the right branch (`main`).
- [x] Commit messages are clear and describe what and why rather than how.
- [x] The website builds successfully (`make prod`).
- [x] Documentation impact checked: `CLAUDE.md` updated alongside the PR template change.

By submitting this pull request, I confirm that my contribution is compliant with
the [LICENSE](https://github.com/gmarciani/gmarciani.github.io/blob/HEAD/LICENSE).
